### PR TITLE
Remove globals

### DIFF
--- a/collider.lua
+++ b/collider.lua
@@ -1,5 +1,5 @@
 -- a Collider object, wrapping shape, body, and fixtue
-
+local set_funcs, lp, lg = unpack(require("utils"))
 
 local Collider = {}
 Collider.__index = Collider

--- a/collider.lua
+++ b/collider.lua
@@ -5,7 +5,7 @@ local Collider = {}
 Collider.__index = Collider
 
 
-COLLIDER_TYPES = {
+local COLLIDER_TYPES = {
    CIRCLE = "Circle",
    CIRC = "Circle",
    RECTANGLE = "Rectangle",

--- a/init.lua
+++ b/init.lua
@@ -31,8 +31,8 @@ function set_funcs(mainobject, subobject)
    end
 end
 
-lp = love.physics
-lg = love.graphics
+local lp = love.physics
+local lg = love.graphics
 
 local Collider = require('breezefield/collider')
 local World = require('breezefield/world')

--- a/init.lua
+++ b/init.lua
@@ -9,33 +9,10 @@
 
 local bf = {}
 
-local phys = love.physics
-
-
--- function used for both
-function set_funcs(mainobject, subobject)
-   -- this function assigns functions of a subobject to a primary object
-   --[[
-      mainobject: the table to which to assign the functions
-      subobject: the table whose functions to assign
-      no output
-   --]]
-   for k, v in pairs(subobject.__index) do
-      if k ~= '__gc' and k ~= '__eq' and k ~= '__index'
-	 and k ~= '__tostring' and k ~= 'destroy' and k ~= 'type'
-         and k ~= 'typeOf'and k ~= 'getUserData' and k ~= 'setUserData' then
-	 mainobject[k] = function(mainobject, ...)
-	    return v(subobject, ...)
-	 end
-      end
-   end
-end
-
-local lp = love.physics
-local lg = love.graphics
 
 local Collider = require('breezefield/collider')
 local World = require('breezefield/world')
+
 
 function bf.newWorld(...)
    return bf.World:new(...)

--- a/test/main.lua
+++ b/test/main.lua
@@ -1,5 +1,14 @@
+local pre_globals = {}
+for n, v in pairs(_G) do
+   pre_globals[n] = v
+end
+
 bf = require("breezefield")
 
+for n, v in pairs(_G) do
+   assert(n == 'bf' or pre_globals[n] ~= nil, 'stray global variable: '.. n)
+end
+   
 -- TODO split into multiple test scripts
 function love.load()
    world = bf.newWorld(0, 90.81, true)

--- a/utils.lua
+++ b/utils.lua
@@ -1,0 +1,20 @@
+-- function used for both
+local function set_funcs(mainobject, subobject)
+   -- this function assigns functions of a subobject to a primary object
+   --[[
+      mainobject: the table to which to assign the functions
+      subobject: the table whose functions to assign
+      no output
+   --]]
+   for k, v in pairs(subobject.__index) do
+      if k ~= '__gc' and k ~= '__eq' and k ~= '__index'
+	 and k ~= '__tostring' and k ~= 'destroy' and k ~= 'type'
+         and k ~= 'typeOf'and k ~= 'getUserData' and k ~= 'setUserData' then
+	 mainobject[k] = function(mainobject, ...)
+	    return v(subobject, ...)
+	 end
+      end
+   end
+end
+
+return {set_funcs, love.physics, love.graphics}

--- a/world.lua
+++ b/world.lua
@@ -10,7 +10,7 @@
 -- TODO make updating work from here too
 local phys=love.physics
 
-mlib = require('mlib/mlib')
+local mlib = require('mlib/mlib')
 -- NOTE for now use handy mlib functions, but maybe change later
 -- they are a little overkill
 -- ooh maybe take the chance to practice c and lua integration?

--- a/world.lua
+++ b/world.lua
@@ -8,12 +8,49 @@
    or for beginContact if the colliders are sensors
 --]]
 -- TODO make updating work from here too
-local phys=love.physics
 
+local set_funcs, lp, lg = unpack(require("utils"))
 local mlib = require('mlib/mlib')
 -- NOTE for now use handy mlib functions, but maybe change later
 -- they are a little overkill
 -- ooh maybe take the chance to practice c and lua integration?
+
+-- a helper for getting intersections from mlib
+
+local function checkIntersections(colls, intersection_type, ...)
+   -- iterate through a table to see if they intersect
+   local function get_mlib_intersection(collider, type_2, ...)
+      local type_1 = collider.collider_type
+      local func =  mlib[type_1:lower()]['get'..type_2..'Intersection']
+      -- awkward
+      -- would prefer if type_1 args were consistenly required first
+      -- messing with these args is awkward
+      -- is this really cleaner than individual calls within functions?
+      -- TODO send a pull request to mlib?
+      if type_1 == 'Circle' then
+	 local args = {collider:getSpatialIdentity()}
+	 for i, v in ipairs({...}) do
+	    args[#args+1] = v
+	 end
+	 return func(unpack(args))
+	 -- will work whether type_2 is polygon or Circle
+      else
+	 local args = {...}
+	 args[#args+1] = {collider:getSpatialIdentity()}
+	 return func(unpack(args))
+	 -- getPolygonPolygonIntersection requires tables
+	 -- getPolygonCircleIntersection wants x,y,r and then table
+      end
+   end
+
+   for i, c in ipairs(colls) do
+      isin = get_mlib_intersection(c, intersection_type, ...)
+      if not isin then table.remove(colls, i) end
+   end
+   return colls
+end
+
+---------------------------------------------------
 
 
 local World = {}
@@ -174,42 +211,6 @@ function World:queryCircleArea(x, y, r)
 end
 
 
--- a helper for getting intersections from mlib
-
-function checkIntersections(colls, intersection_type, ...)
-   -- iterate through a table to see if they intersect
-   local function get_mlib_intersection(collider, type_2, ...)
-      local type_1 = collider.collider_type
-      local func =  mlib[type_1:lower()]['get'..type_2..'Intersection']
-      -- awkward
-      -- would prefer if type_1 args were consistenly required first
-      -- messing with these args is awkward
-      -- is this really cleaner than individual calls within functions?
-      -- TODO send a pull request to mlib?
-      if type_1 == 'Circle' then
-	 local args = {collider:getSpatialIdentity()}
-	 for i, v in ipairs({...}) do
-	    args[#args+1] = v
-	 end
-	 return func(unpack(args))
-	 -- will work whether type_2 is polygon or Circle
-      else
-	 local args = {...}
-	 args[#args+1] = {collider:getSpatialIdentity()}
-	 return func(unpack(args))
-	 -- getPolygonPolygonIntersection requires tables
-	 -- getPolygonCircleIntersection wants x,y,r and then table
-      end
-   end
-
-   for i, c in ipairs(colls) do
-      isin = get_mlib_intersection(c, intersection_type, ...)
-      if not isin then table.remove(colls, i) end
-   end
-   return colls
-end
-
----------------------------------------------------
 
 function World:update(dt)
    -- update physics world


### PR DESCRIPTION
Remove all global varaibles that can interfere with the ones defined by the developer in their game project

Honestly I think it's a bit of a design flaw in lua to export all of a module's globals. Means you have to remember to localize everything. 