### PR TITLE
Fix querying and allow Edge-based querying

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,13 +24,17 @@
 * functionality
 ** easily create physics objects (body + shape + fixture)
   #+BEGIN_SRC lua
-  bf.Collider.new()
+  world:newCollider(<shape_type>, <shape_args>, <table_to_use>(optional))
+  #+END_SRC
+  or
+  #+BEGIN_SRC lua
+  bf.Collider.new(<shape_type>, <shape_args>)
   #+END_SRC 
-** query rectangle, circle, and PolygonArea
+** query rectangle, circle, edge, or polygon areas
   #+BEGIN_SRC lua
   world:queryRectangleArea(x1, y1, x2, y2)
   #+END_SRC 
-  *NOTE* queryCircleArea and queryPolygonArea may not work for Edge or Chain colliders, or when the queried area is wholly inside the collider. I'm working on fixing this.
+
 ** love.physics.<object> methods mapped to breezefield objects
   #+BEGIN_SRC lua
   Collider:<methodname> (e.g. get/setRestitution, get/setX, etc...)
@@ -57,7 +61,6 @@
 * Installation
   I reccomend you ensure you understand love.physics, as breezefield mostly just wraps that. You can start [[https://love2d.org/wiki/Tutorial:Physics][here]]. 
   To install simply clone or download the repository and place breezefield anywhere in your lua path or in your project directory.
-  breezefield presently relies on [[https://github.com/davisdude/mlib][mlib]], so download that too and put it in your path as well (or inside breezefield)
 
 * example/tutorial
 ** Basics
@@ -156,7 +159,7 @@ function little_ball:draw(alpha)
 end
 #+END_SRC
 
-** query the world (supports rectangle, circle, and polygon)
+** query the world (supports rectangle, circle, polygon and edge)
 #+BEGIN_SRC lua
 function love.mousepressed()
    local x, y
@@ -181,7 +184,6 @@ little_ball.identity = little_ball
    for now, see:
    [[https://love2d.org/wiki/Contact:setEnabled]]
    [[https://love2d.org/wiki/Fixture:setFilterData]]
-
 
 
    

--- a/collider.lua
+++ b/collider.lua
@@ -49,5 +49,18 @@ function Collider:getSpatialIdentity()
    end
 end
 
+function Collider:collider_contacts()
+   local contacts = self:getContacts()
+   local colliders = {}
+   for i, contact in ipairs(contacts) do
+      local f1, f2 = contact:getFixtures()
+      if f1 == self.fixture then
+	 colliders[#colliders+1] = f2:getUserData()
+      else
+	 colliders[#colliders+1] = f1:getUserData()
+      end
+   end
+   return colliders
+end
 
 return Collider

--- a/test/test_queryareas/main.lua
+++ b/test/test_queryareas/main.lua
@@ -38,6 +38,9 @@ function love.load()
    local aline = bf.Collider.new(world, 'edge', 100, 100, 120, 120, 150, 150)
    local edgeinpoly = world:queryRectangleArea(90, 90, 125, 125)
    assert(edgeinpoly[1] == aline and #edgeinpoly == 1)
+
+   local circleinlines = world:queryEdgeArea(300, 300, 350, 350)
+   assert(circleinlines[1] == ball and #circleinlines == 1)
    
    print('tests passed')
    love.event.quit()

--- a/test/test_queryareas/main.lua
+++ b/test/test_queryareas/main.lua
@@ -29,6 +29,16 @@ function love.load()
    -- test polygon intersects polygon
    local polyintpoly = world:queryPolygonArea(505, 505, 499, 551, 551, 551, 551, 499)
    assert(polyintpoly[1] == tri and #polyintpoly == 1)
+
+   -- test region fully inside collider
+   local circlearoundcircle = world:queryCircleArea(325, 325, 5)
+   assert(circlearoundcircle[1] == ball and #circlearoundcircle == 1)
+
+   -- test line collider
+   local aline = bf.Collider.new(world, 'edge', 100, 100, 120, 120, 150, 150)
+   local edgeinpoly = world:queryRectangleArea(90, 90, 125, 125)
+   assert(edgeinpoly[1] == aline and #edgeinpoly == 1)
+   
    print('tests passed')
    love.event.quit()
 end

--- a/world.lua
+++ b/world.lua
@@ -11,61 +11,6 @@
 -- TODO: update test and tutorial
 local Collider = require('breezefield/collider')
 local set_funcs, lp, lg, COLLIDER_TYPES = unpack(require("breezefield/utils"))
-local mlib = require('mlib/mlib')
--- NOTE for now use handy mlib functions, but maybe change later
--- they are a little overkill
--- ooh maybe take the chance to practice c and lua integration?
-
--- a helper for getting intersections from mlib
-
-local function checkInside(colls, intersection_type, ...)
-   -- iterate through a table to see if they intersect
-   -- ... is table of vertices for polygons, x, y, r for circle
-   local function get_mlib_intersection(collider, type_1, ...)
-      local type_2 = collider.collider_type
-
-      local is_intersect =  mlib[type_1:lower()]['get'..type_2..'Intersection']
-      local is_inside = mlib[type_1:lower()]['is'..type_2..'CompletelyInside']
-      -- awkward
-      -- would prefer if type_1 args were consistenly required first
-      -- messing with these args is awkward
-      -- is this really cleaner than individual calls within functions?
-      -- TODO send a pull request to mlib?
-
-      -- four possibilities:
-      -- circle-circle
-      ---- ..., collider
-      -- circle-polygon
-      ---- ..., unpack(collider)
-      -- polygon-circle
-      ---- unpack(collider), ...
-      ---- polygon-polygon
-      ----- ..., unpack(collider)
-      
-      if type_2 == 'Circle' then
-	 local args = {collider:getSpatialIdentity()}
-	 for i, v in ipairs({...}) do
-	    args[#args+1] = v
-	 end
-	 return is_intersect(unpack(args)) or is_inside(unpack(args))
-	 -- will work whether type_2 is polygon or Circle
-      else
-	 local args = {...}
-	 args[#args+1] = {collider:getSpatialIdentity()}
-	 return is_intersect(unpack(args)) or is_inside(unpack(args))
-	 -- getPolygonPolygonIntersection requires tables
-	 -- getPolygonCircleIntersection wants x,y,r and then table
-      end
-   end
-
-   for i, c in ipairs(colls) do
-      isin = get_mlib_intersection(c, intersection_type, ...)
-      if not isin then table.remove(colls, i) end
-   end
-   return colls
-end
-
----------------------------------------------------
 
 
 local World = {}
@@ -171,44 +116,65 @@ function World:queryRectangleArea(x1, y1, x2, y2)
    return colls
 end
 
+local function check_vertices(vertices)
+   if #vertices % 2 ~= 0 then
+      error('vertices must be a multiple of 2')
+   elseif #vertices < 4 then
+      error('must have at least 2 vertices with x and y each')
+   end
+end
+
+local function query_region(world, coll_type, args)
+   local collider = world:newCollider(coll_type, args)
+   collider:setSensor(true)
+   world:update(0)
+   local colls = collider:collider_contacts(collider)
+   collider:destroy()
+   return colls
+end
 
 function World:queryPolygonArea(...)
    -- query an area enclosed by the lines connecting a series of points
    --[[
       inputs:
-      (x, y, ) X 3+: floats, x and y coordinates of the points defining polygon
+        x1, y1, x2, y2, ... floats, the x and y positions defining polygon
       outputs:
-      colls: table, all Colliders intersecting the area
+        colls: table, all Colliders intersecting the area
    --]]
    local vertices = {...}
    if type(vertices[1]) == 'table' then
       vertices = vertices[1]
    end
-   local checkcoll = self:newCollider(
-      'Polygon', vertices)
-   checkcoll:setSensor(true)
-   self:update(0)
-   local colls = checkcoll:collider_contacts(checkcoll)
-   checkcoll:destroy()
-   return colls
+   check_vertices(vertices)
+   return query_region(self, 'Polygon', vertices)
 end
 
 function World:queryCircleArea(x, y, r)
    -- get all colliders in a circle are
    --[[
       inputs: 
-      x, y, r: floats, x, y and radius of circle
+        x, y, r: floats, x, y and radius of circle
       outputs:
-      colls: table: colliders in area
+        colls: table: colliders in area
    ]]--
-   local checkcoll = self:newCollider('Circle', {x, y, r})
-   checkcoll:setSensor(true)
-   self:update(0)
-   local colls = checkcoll:collider_contacts(checkcoll)
-   checkcoll:destroy()
-   return colls
+   return query_region(self, 'Circle', {x, y, r})
 end
 
+function World:queryEdgeArea(...)
+   -- get all colliders along a (series of) line(s)
+   --[[
+      inputs:
+        x1, y1, x2, y2, ... floats, the x and y positions defining lines
+       outpts:
+        colls: table: colliders intersecting these lines
+   --]]
+   local vertices = {...}
+   if type(vertices[1]) == 'table' then
+      vertices = vertices[1]
+   end
+   check_vertices(vertices)
+   return  query_region(self, 'Edge', vertices)
+end
 
 
 function World:update(dt)

--- a/world.lua
+++ b/world.lua
@@ -171,6 +171,7 @@ function World:queryRectangleArea(x1, y1, x2, y2)
    return colls
 end
 
+
 function World:queryPolygonArea(...)
    -- query an area enclosed by the lines connecting a series of points
    --[[
@@ -183,30 +184,13 @@ function World:queryPolygonArea(...)
    if type(vertices[1]) == 'table' then
       vertices = vertices[1]
    end
-
-   local function add_coordinate(value, coords, max, min)
-      coords[#coords+1] = value
-      if value > max then max = value end
-      if value < min then min = value end
-      return coords, max, min
-   end
-
-   local x = {}
-   local maxx = -math.huge
-   local minx = math.huge
-   local y = {}
-   local maxy = -math.huge
-   local miny = math.huge
-   for i, v in ipairs(vertices) do
-      if i % 2 == 1 then
-	 x, maxx, minx = add_coordinate(v, x, maxx, minx)
-      else
-	 y, maxy, miny = add_coordinate(v, y, maxy, miny)
-      end
-   end
-   local colls = self:queryRectangleArea(minx, miny, maxx, maxy)
-
-   return checkInside(colls, 'Polygon', vertices)
+   local checkcoll = self:newCollider(
+      'Polygon', vertices)
+   checkcoll:setSensor(true)
+   self:update(0)
+   local colls = checkcoll:collider_contacts(checkcoll)
+   checkcoll:destroy()
+   return colls
 end
 
 function World:queryCircleArea(x, y, r)
@@ -217,13 +201,12 @@ function World:queryCircleArea(x, y, r)
       outputs:
       colls: table: colliders in area
    ]]--
-   local maxx = x + r
-   local minx = x - r
-   local maxy = y + r
-   local miny = y - r
-   local colls = self:queryRectangleArea(minx, miny,
-					 maxx, maxy)
-   return checkInside(colls, 'Circle', x, y, r)
+   local checkcoll = self:newCollider('Circle', {x, y, r})
+   checkcoll:setSensor(true)
+   self:update(0)
+   local colls = checkcoll:collider_contacts(checkcoll)
+   checkcoll:destroy()
+   return colls
 end
 
 


### PR DESCRIPTION
By creating, using, and immediately deleting colliders we can very simply accomplish reliable queries. If a game requires very frequent queries, this will probably be inefficient - in that case it is probably best for the user to hang onto a sensor Collider and move it as desired to query