### PR TITLE
identify and fix bug with area querying

### DIFF
--- a/collider.lua
+++ b/collider.lua
@@ -53,11 +53,13 @@ function Collider:collider_contacts()
    local contacts = self:getContacts()
    local colliders = {}
    for i, contact in ipairs(contacts) do
-      local f1, f2 = contact:getFixtures()
-      if f1 == self.fixture then
-	 colliders[#colliders+1] = f2:getUserData()
-      else
-	 colliders[#colliders+1] = f1:getUserData()
+      if contact:isTouching() then
+	 local f1, f2 = contact:getFixtures()
+	 if f1 == self.fixture then
+	    colliders[#colliders+1] = f2:getUserData()
+	 else
+	    colliders[#colliders+1] = f1:getUserData()
+	 end
       end
    end
    return colliders


### PR DESCRIPTION
love.physics.Contact was assumed to mean that two fixtures are
touching
turns out this isn't neccessarily the case