### PR TITLE
Fix "Forum" link on README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -205,5 +205,5 @@ little_ball.identity = little_ball
    
 * links
 ** forum
-   [[forum][https://love2d.org/forums/viewtopic.php?f=5&t=86113&p=224718#p224718]]
+   [[https://love2d.org/forums/viewtopic.php?f=5&t=86113&p=224718#p224718][forum]]
    


### PR DESCRIPTION
Just a small issue with one of the links. [Org mode links](https://orgmode.org/manual/Link-Format.html) should have the URL part first.

Interestingly, it looks like it is currently being interpreted as an [internal repo link](https://github.com/HDictus/breezefield/blob/master/forum).